### PR TITLE
feat: extend allowed_actors to bypass human actor validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,13 +879,13 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
 
 ### Allowed Actors
 
-The `allowed_actors` input allows specific GitHub users or bots to trigger the action even without write permissions to the repository. This is useful for:
+The `allowed_actors` input allows specific GitHub users or bots to trigger the action even without write permissions to the repository and bypasses human actor checks. This is useful for:
 
 - Automated tools like `copilot-pull-request-reviewer`
 - Team members who should be able to request Claude's help without full repository access
 - Trusted bots like Dependabot
 
-**Security Note**: This feature bypasses GitHub's standard permission model. Only add actors you trust, as they will be able to trigger Claude to make changes to your repository.
+**Security Note**: This feature bypasses both GitHub's standard permission model and human actor validation. Only add actors you trust, as they will be able to trigger Claude to make changes to your repository.
 
 ```yaml
 - uses: anthropics/claude-code-action@v1

--- a/action.yml
+++ b/action.yml
@@ -68,8 +68,9 @@ inputs:
     default: ""
   allowed_actors:
     description: |
-      Additional actors allowed to trigger the action regardless of repository permissions.
-      This bypasses the standard GitHub permission model - use with trusted actors only.
+      Additional actors allowed to trigger the action regardless of repository permissions or actor type.
+      This bypasses both the standard GitHub permission model and human actor checks - use with trusted actors only.
+      Allows bots and automated tools to trigger the action when explicitly allowed.
       Accepts comma-separated or newline-separated values.
     required: false
     default: ""

--- a/src/github/validation/actor.ts
+++ b/src/github/validation/actor.ts
@@ -12,6 +12,17 @@ export async function checkHumanActor(
   octokit: Octokit,
   githubContext: ParsedGitHubContext,
 ) {
+  // Check if actor is in the allowed actors list
+  if (githubContext.inputs.allowedActors && githubContext.inputs.allowedActors.length > 0) {
+    const isAllowed = githubContext.inputs.allowedActors.some(
+      (allowedActor) => allowedActor.toLowerCase() === githubContext.actor.toLowerCase()
+    );
+    if (isAllowed) {
+      console.log(`Actor ${githubContext.actor} is in the allowed actors list, bypassing human check`);
+      return;
+    }
+  }
+
   // Fetch user information from GitHub API
   const { data: userData } = await octokit.users.getByUsername({
     username: githubContext.actor,

--- a/test/actor-validation.test.ts
+++ b/test/actor-validation.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn, jest } from "bun:test";
+import { checkHumanActor } from "../src/github/validation/actor";
+import type { ParsedGitHubContext } from "../src/github/context";
+
+describe("checkHumanActor", () => {
+  let consoleLogSpy: any;
+
+  beforeEach(() => {
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  const createMockOctokit = () => {
+    return {
+      users: {
+        getByUsername: jest.fn().mockResolvedValue({
+          data: { type: "Bot" },
+        }),
+      },
+    } as any;
+  };
+
+  const createContext = (overrides: Partial<ParsedGitHubContext> = {}): ParsedGitHubContext => ({
+    runId: "12345",
+    eventName: "issue_comment",
+    eventAction: undefined,
+    repository: {
+      owner: "test-owner",
+      repo: "test-repo",
+      full_name: "test-owner/test-repo",
+    },
+    actor: "test-bot",
+    inputs: {
+      mode: "tag",
+      triggerPhrase: "@claude",
+      assigneeTrigger: "",
+      labelTrigger: "",
+      allowedTools: [],
+      allowedActors: [],
+      disallowedTools: [],
+      customInstructions: "",
+      directPrompt: "",
+      overridePrompt: "",
+      branchPrefix: "claude/",
+      useStickyComment: false,
+      additionalPermissions: new Map(),
+      useCommitSigning: false,
+    },
+    entityNumber: 123,
+    isPR: false,
+    payload: {} as any,
+    ...overrides,
+  });
+
+  test("should throw error when actor is a bot", async () => {
+    const mockOctokit = createMockOctokit();
+    const context = createContext();
+    
+    await expect(checkHumanActor(mockOctokit, context)).rejects.toThrow(
+      "Workflow initiated by non-human actor: test-bot (type: Bot)."
+    );
+  });
+
+  test("should bypass check when actor is in allowed actors list", async () => {
+    const mockOctokit = createMockOctokit();
+
+    const context = createContext({
+      actor: "copilot-pull-request-reviewer",
+      inputs: {
+        ...createContext().inputs,
+        allowedActors: ["copilot-pull-request-reviewer", "another-bot"],
+      },
+    });
+
+    // Should not throw
+    await checkHumanActor(mockOctokit, context);
+    
+    // Verify the API was never called
+    expect(mockOctokit.users.getByUsername).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Actor copilot-pull-request-reviewer is in the allowed actors list, bypassing human check"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR extends the existing `allowed_actors` feature to also bypass the human actor validation check, allowing bots and automated tools to trigger the action when explicitly allowed.

## Motivation

Currently, the `allowed_actors` feature only bypasses repository permission checks. However, there's a second validation (`checkHumanActor`) that blocks non-human actors (bots) from triggering the action. This prevents useful automation tools like GitHub Copilot's pull request reviewer bot from using the action, even when explicitly allowed.

## Changes

- **Modified `checkHumanActor` function**: Added logic to check if the actor is in the `allowedActors` list before validating actor type
- **Updated documentation**: Clarified in both `action.yml` and `README.md` that `allowed_actors` bypasses both permission checks and human actor validation
- **Added test coverage**: Created `test/actor-validation.test.ts` with tests for the bypass functionality

## Test plan

- [x] Added unit tests for the new bypass logic
- [x] All existing tests continue to pass
- [ ] Manual testing with a bot account in the allowed_actors list

## Security Considerations

This change maintains security by requiring explicit allowlisting. Only actors specifically added to `allowed_actors` can bypass the human check, ensuring administrators maintain full control over which bots can trigger the action.

🤖 Generated with [Claude Code](https://claude.ai/code)