### PR TITLE
feat: Add target_repository input for cross-repository operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ jobs:
 | `allowed_actors`               | Additional actors allowed to trigger the action regardless of repository permissions (comma or newline-separated)      | No       | ""        |
 | `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                     | No       | ""        |
 | `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands      | No       | `false`   |
+| `target_repository`            | Override the target repository (format: owner/repo). Used for cross-repository operations                              | No       | -         |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock or Vertex)
 
@@ -606,6 +607,28 @@ You can use the `max_turns` parameter to limit the number of back-and-forth exch
 ```
 
 When the turn limit is reached, Claude will stop execution gracefully. Choose a value that gives Claude enough turns to complete typical tasks while preventing excessive usage.
+
+### Cross-Repository Operations
+
+The `target_repository` input allows the action to operate on repositories different from where the workflow is running. This is useful for:
+
+- Centralized workflow management across multiple repositories
+- Cross-repository code reviews and analysis
+- Multi-repository automation tasks
+
+```yaml
+- uses: anthropics/claude-code-action@beta
+  with:
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    target_repository: "octocat/hello-world"  # Format: owner/repo
+    # ... other inputs
+```
+
+**Important Notes**:
+- The GitHub token must have access to the target repository
+- The format must be exactly `owner/repo` (e.g., `octocat/hello-world`)
+- API calls and operations will target the specified repository
+- This is particularly useful when running workflows triggered by events in other repositories
 
 ### Custom Tools
 

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,9 @@ inputs:
     description: "Claude Code settings as JSON string or path to settings JSON file"
     required: false
     default: ""
+  target_repository:
+    description: "Override the target repository (format: owner/repo). Used for cross-repository operations."
+    required: false
 
   # Auth configuration
   anthropic_api_key:
@@ -170,6 +173,7 @@ runs:
         ACTIONS_TOKEN: ${{ github.token }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
+        TARGET_REPOSITORY: ${{ inputs.target_repository }}
 
     - name: Install Base Action Dependencies
       if: steps.prepare.outputs.contains_trigger == 'true'

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -117,14 +117,22 @@ export function parseGitHubContext(): GitHubContext {
     repository: (() => {
       // Check for repository override from input
       const targetRepo = process.env.TARGET_REPOSITORY;
-      if (targetRepo && targetRepo.includes('/')) {
-        const [owner, repo] = targetRepo.split('/');
-        console.log(`Using repository override: ${targetRepo}`);
-        return {
-          owner,
-          repo,
-          full_name: targetRepo,
-        };
+      if (targetRepo) {
+        const parts = targetRepo.split('/');
+        if (parts.length === 2) {
+          const [owner, repo] = parts.map(part => part.trim());
+          if (owner && repo) {
+            console.log(`Using repository override: ${targetRepo}`);
+            return {
+              owner,
+              repo,
+              full_name: `${owner}/${repo}`,
+            };
+          }
+        }
+        throw new Error(
+          `Invalid TARGET_REPOSITORY format: "${targetRepo}". Expected "owner/repo" (e.g., "octocat/hello-world").`
+        );
       }
       // Default to context repository
       return {

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -114,11 +114,25 @@ export function parseGitHubContext(): GitHubContext {
   const commonFields = {
     runId: process.env.GITHUB_RUN_ID!,
     eventAction: context.payload.action,
-    repository: {
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      full_name: `${context.repo.owner}/${context.repo.repo}`,
-    },
+    repository: (() => {
+      // Check for repository override from input
+      const targetRepo = process.env.TARGET_REPOSITORY;
+      if (targetRepo && targetRepo.includes('/')) {
+        const [owner, repo] = targetRepo.split('/');
+        console.log(`Using repository override: ${targetRepo}`);
+        return {
+          owner,
+          repo,
+          full_name: targetRepo,
+        };
+      }
+      // Default to context repository
+      return {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        full_name: `${context.repo.owner}/${context.repo.repo}`,
+      };
+    })(),
     actor: context.actor,
     inputs: {
       mode: modeInput as ModeName,

--- a/test/github/context.test.ts
+++ b/test/github/context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   parseMultilineInput,
   parseAdditionalPermissions,
@@ -111,5 +111,113 @@ packages: write`;
     const result = parseAdditionalPermissions(input);
     expect(result.get("actions")).toBe("read");
     expect(result.size).toBe(1);
+  });
+});
+
+describe("parseGitHubContext - repository override", () => {
+  // Store original env vars
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clear module cache to ensure fresh imports
+    mock.module("@actions/github", () => ({
+      context: {
+        eventName: "issues",
+        repo: {
+          owner: "original",
+          repo: "repo"
+        },
+        actor: "testuser",
+        payload: {
+          action: "opened",
+          issue: {
+            number: 1,
+            title: "Test issue",
+            body: "Test body"
+          }
+        }
+      }
+    }));
+
+    // Setup minimal env vars
+    process.env.GITHUB_RUN_ID = "12345";
+    process.env.MODE = "tag"; // Default mode
+  });
+
+  afterEach(() => {
+    // Restore original env vars
+    Object.keys(process.env).forEach(key => {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    });
+    Object.assign(process.env, originalEnv);
+    mock.restore();
+  });
+
+  it("should use default repository when TARGET_REPOSITORY is not set", async () => {
+    const { parseGitHubContext } = await import("../../src/github/context");
+    const context = parseGitHubContext();
+    expect(context.repository.owner).toBe("original");
+    expect(context.repository.repo).toBe("repo");
+    expect(context.repository.full_name).toBe("original/repo");
+  });
+
+  it("should override repository when valid TARGET_REPOSITORY is set", async () => {
+    process.env.TARGET_REPOSITORY = "override/repository";
+    const { parseGitHubContext } = await import("../../src/github/context");
+    const context = parseGitHubContext();
+    expect(context.repository.owner).toBe("override");
+    expect(context.repository.repo).toBe("repository");
+    expect(context.repository.full_name).toBe("override/repository");
+  });
+
+  it("should trim whitespace from repository parts", async () => {
+    process.env.TARGET_REPOSITORY = " override / repository ";
+    const { parseGitHubContext } = await import("../../src/github/context");
+    const context = parseGitHubContext();
+    expect(context.repository.owner).toBe("override");
+    expect(context.repository.repo).toBe("repository");
+    expect(context.repository.full_name).toBe("override/repository");
+  });
+
+  it("should throw error for invalid repository format - no slash", async () => {
+    process.env.TARGET_REPOSITORY = "invalidformat";
+    const { parseGitHubContext } = await import("../../src/github/context");
+    expect(() => parseGitHubContext()).toThrow(
+      'Invalid TARGET_REPOSITORY format: "invalidformat". Expected "owner/repo" (e.g., "octocat/hello-world").'
+    );
+  });
+
+  it("should throw error for invalid repository format - multiple slashes", async () => {
+    process.env.TARGET_REPOSITORY = "owner/repo/extra";
+    const { parseGitHubContext } = await import("../../src/github/context");
+    expect(() => parseGitHubContext()).toThrow(
+      'Invalid TARGET_REPOSITORY format: "owner/repo/extra". Expected "owner/repo" (e.g., "octocat/hello-world").'
+    );
+  });
+
+  it("should throw error for empty owner", async () => {
+    process.env.TARGET_REPOSITORY = "/repo";
+    const { parseGitHubContext } = await import("../../src/github/context");
+    expect(() => parseGitHubContext()).toThrow(
+      'Invalid TARGET_REPOSITORY format: "/repo". Expected "owner/repo" (e.g., "octocat/hello-world").'
+    );
+  });
+
+  it("should throw error for empty repo", async () => {
+    process.env.TARGET_REPOSITORY = "owner/";
+    const { parseGitHubContext } = await import("../../src/github/context");
+    expect(() => parseGitHubContext()).toThrow(
+      'Invalid TARGET_REPOSITORY format: "owner/". Expected "owner/repo" (e.g., "octocat/hello-world").'
+    );
+  });
+
+  it("should throw error for whitespace-only parts", async () => {
+    process.env.TARGET_REPOSITORY = "  /  ";
+    const { parseGitHubContext } = await import("../../src/github/context");
+    expect(() => parseGitHubContext()).toThrow(
+      'Invalid TARGET_REPOSITORY format: "  /  ". Expected "owner/repo" (e.g., "octocat/hello-world").'
+    );
   });
 });


### PR DESCRIPTION
## Summary

This PR adds support for cross-repository operations by allowing the action to override the target repository context.

## Problem

When running the Claude action in a workflow that checks out a different repository (e.g., for cross-repository metareviews), the action still uses the original repository context from GitHub Actions environment variables. This causes API calls to target the wrong repository.

## Solution

- Added `target_repository` input to action.yml
- Modified `parseGitHubContext()` in context.ts to check for repository override
- Repository override is used when provided, otherwise defaults to standard context

## Testing

- Existing tests pass
- Backward compatible - no changes needed for existing workflows
- New workflows can specify `target_repository: owner/repo` to operate on different repositories

## Use Case

This enables the metareviewer workflow to analyze PRs in other repositories while running from a central workflow repository.