### PR TITLE
Add CODEOWNERS with @pierreca and @arathald as owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners — required reviewers for all PRs
+* @pierreca @arathald


### PR DESCRIPTION
Adds a CODEOWNERS file making @pierreca and @arathald the global code owners. (Repo had no CODEOWNERS before.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)